### PR TITLE
Add support for x-www-browser and www-browser in linux

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -9,9 +9,9 @@ func openBrowser(url string) error {
 		if wslErr := runCmd("wslview", url); wslErr != nil {
 			return err
 		}
-
-		return nil
 	}
+
+	return nil
 }
 
 func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -3,15 +3,18 @@ package browser
 import "os/exec"
 
 func openBrowser(url string) error {
-	// Unfortunately, due to how WSL works, we can't differentiate between WSL and Linux via build tags
-	// So we try xdg-open first, and if that fails, use wslview
-	if err := runCmd("xdg-open", url); err != nil {
-		if wslErr := runCmd("wslview", url); wslErr != nil {
-			return err
+	providers := []string{"xdg-open", "x-www-browser", "www-browser"}
+
+	// There are multiple possible providers to open a browser on linux
+	// One of them is xdg-open, another is x-www-browser, then there's www-browser, etc.
+	// Look for one that exists and run it
+	for _, provider := range providers {
+		if _, err := exec.LookPath(provider); err == nil {
+			return runCmd(provider, url)
 		}
 	}
 
-	return nil
+	return exec.ErrNotFound
 }
 
 func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,6 +1,9 @@
 package browser
 
-import "os/exec"
+import (
+	"os/exec"
+	"strings"
+)
 
 func openBrowser(url string) error {
 	providers := []string{"xdg-open", "x-www-browser", "www-browser"}
@@ -14,7 +17,7 @@ func openBrowser(url string) error {
 		}
 	}
 
-	return exec.ErrNotFound
+	return &exec.Error{Name: strings.Join(providers, ","), Err: ErrNotFound}
 }
 
 func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -3,7 +3,15 @@ package browser
 import "os/exec"
 
 func openBrowser(url string) error {
-	return runCmd("xdg-open", url)
+	// Unfortunately, due to how WSL works, we can't differentiate between WSL and Linux via build tags
+	// So we try xdg-open first, and if that fails, use wslview
+	if err := runCmd("xdg-open", url); err != nil {
+		if wslErr := runCmd("wslview", url); wslErr != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
 func setFlags(cmd *exec.Cmd) {}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -17,7 +17,7 @@ func openBrowser(url string) error {
 		}
 	}
 
-	return &exec.Error{Name: strings.Join(providers, ","), Err: ErrNotFound}
+	return &exec.Error{Name: strings.Join(providers, ","), Err: exec.ErrNotFound}
 }
 
 func setFlags(cmd *exec.Cmd) {}


### PR DESCRIPTION
Those are provider as a way to open a browser in debian and ubuntu and are implemented by various providers. (Including wslu, the browsers themselves, and a bunch of others)